### PR TITLE
update link to coverage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# [Coveralls](http://coveralls.io) for Ruby [![Test Coverage](https://coveralls.io/repos/lemurheavy/coveralls-ruby/badge.png?branch=master)](https://coveralls.io/repos/lemurheavy/coveralls-ruby) [![Build Status](https://secure.travis-ci.org/lemurheavy/coveralls-ruby.png?branch=master)](https://travis-ci.org/lemurheavy/coveralls-ruby)
+# [Coveralls](http://coveralls.io) for Ruby [![Test Coverage](https://coveralls.io/repos/lemurheavy/coveralls-ruby/badge.png?branch=master)](https://coveralls.io/r/lemurheavy/coveralls-ruby) [![Build Status](https://secure.travis-ci.org/lemurheavy/coveralls-ruby.png?branch=master)](https://travis-ci.org/lemurheavy/coveralls-ruby)
 
 ### [Read the docs &rarr;](https://coveralls.io/docs/ruby)


### PR DESCRIPTION
Fixes a 404 link when clicking on the coverage badge.
