### PR TITLE
Removed old 'json' import

### DIFF
--- a/lib/coveralls/rake/task.rb
+++ b/lib/coveralls/rake/task.rb
@@ -1,6 +1,5 @@
 require 'rake'
 require 'rake/tasklib'
-require 'json'
 
 module Coveralls
   class RakeTask < ::Rake::TaskLib


### PR DESCRIPTION
[#17] Having the Rake task 'require json' without coveralls having an explicit dependency on the json gem means the task fails if you don't also depend on the json gem yourself. Removed the 'require' line becase it wasn't doing anything.
