### PR TITLE
Remove warnings

### DIFF
--- a/lib/coveralls.rb
+++ b/lib/coveralls.rb
@@ -80,12 +80,12 @@ module Coveralls
   def should_run?
     # Fail early if we're not on a CI
     unless ENV["CI"] || ENV["JENKINS_URL"] ||
-      ENV["COVERALLS_RUN_LOCALLY"] || @testing
+      ENV["COVERALLS_RUN_LOCALLY"] || (defined?(@testing) && @testing)
       puts "[Coveralls] Outside the Travis environment, not sending data.".yellow
       return false
     end
 
-    if ENV["COVERALLS_RUN_LOCALLY"] || @run_locally
+    if ENV["COVERALLS_RUN_LOCALLY"] || (defined?(@run_locally) && @run_locally)
       puts "[Coveralls] Creating a new job on Coveralls from local coverage results.".cyan
     end
 
@@ -93,6 +93,6 @@ module Coveralls
   end
 
   def noisy?
-    ENV["COVERALLS_NOISY"] || @noisy
+    ENV["COVERALLS_NOISY"] || (defined?(@noisy) && @noisy)
   end
 end


### PR DESCRIPTION
coveralls currently throws a few warnings when I run it with my test suite. These commits remove them.

The second commit might be tackled another way, but the `extend self` makes it really confusing if you're on a module level or not. Like, I _think_ I could just set the class variables inside of `setup!`, but I'm not 100% sure, and this seemed clearer.
