### PR TITLE
expose a will_run? method

### DIFF
--- a/lib/coveralls.rb
+++ b/lib/coveralls.rb
@@ -78,8 +78,7 @@ module Coveralls
 
   def should_run?
     # Fail early if we're not on a CI
-    unless ENV["CI"] || ENV["JENKINS_URL"] ||
-      ENV["COVERALLS_RUN_LOCALLY"] || @testing
+    unless will_run?
       Coveralls::Output.puts("[Coveralls] Outside the Travis environment, not sending data.", :color => "yellow")
       return false
     end
@@ -89,6 +88,10 @@ module Coveralls
     end
 
     true
+  end
+
+  def will_run?
+    ENV["CI"] || ENV["JENKINS_URL"] || ENV["COVERALLS_RUN_LOCALLY"] || @testing
   end
 
   def noisy?

--- a/spec/coveralls/coveralls_spec.rb
+++ b/spec/coveralls/coveralls_spec.rb
@@ -7,6 +7,20 @@ describe Coveralls do
     Coveralls.testing = true
   end
 
+  describe "#will_run?" do
+    it "checks CI environemnt variables" do
+      Coveralls.will_run?.should be_true
+    end
+
+    context "with CI disabled" do
+      before { Coveralls.testing = false }
+
+      it "indicates no run" do
+        Coveralls.will_run?.should be_false
+      end
+    end
+  end
+
   describe "#should_run?" do
     it "outputs to stdout when running locally" do
       Coveralls.testing = false


### PR DESCRIPTION
in my `spec_helper.rb` i would like to disable coveralls for regular rspec runs (better performance, no noise).

with the `will_run?` method, i can do something like this:

``` ruby
require 'coveralls'
Coveralls.wear!('rails') if Coveralls.will_run?
```

if you think that there is a better solution to this, please give me some feedback.
