### PR TITLE
Use 'double' instead of 'mock' for rspec-mocks

### DIFF
--- a/spec/coveralls/simplecov_spec.rb
+++ b/spec/coveralls/simplecov_spec.rb
@@ -61,7 +61,7 @@ describe Coveralls::SimpleCov::Formatter do
 
     context "with api error" do
       it "rescues" do
-        e = RestClient::ResourceNotFound.new mock('HTTP Response', :code => '502')
+        e = RestClient::ResourceNotFound.new double('HTTP Response', :code => '502')
         silence do
           Coveralls::SimpleCov::Formatter.new.display_error(e).should be_false
         end


### PR DESCRIPTION
'mock' is deprecated after rspec-mocks 2.14.0.rc1(2013-05-27 released).
'mock' method may be removed for rspec-mocks 3.0.0.

And, this fix can remove following warnings.
DEPRECATION: mock is deprecated. Use double instead. Called from spec/coveralls/simplecov_spec.rb:64:in `block (4 levels) in <top (required)>'.
