### PR TITLE
Fix RSpec deprecation

### DIFF
--- a/spec/coveralls/simplecov_spec.rb
+++ b/spec/coveralls/simplecov_spec.rb
@@ -61,7 +61,7 @@ describe Coveralls::SimpleCov::Formatter do
 
     context "with api error" do
       it "rescues" do
-        e = RestClient::ResourceNotFound.new mock('HTTP Response', :code => '502')
+        e = RestClient::ResourceNotFound.new double('HTTP Response', :code => '502')
         silence do
           Coveralls::SimpleCov::Formatter.new.display_error(e).should be_false
         end


### PR DESCRIPTION
```
DEPRECATION: mock is deprecated. Use double instead.
```
