### PR TITLE
Travis - Run Ruby 2.1.0, get Rubinius running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
 rvm:
-  - rbx-19mode
+  - rbx
   - jruby-19mode
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 2.1.0
   - ruby-head
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,9 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'simplecov', :require => false
+
+platform :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'json'
+  gem 'rubinius-developer_tools'
+end


### PR DESCRIPTION
1. Added Ruby 2.1.0 to the list of Rubies tested by Travis.
2. Updated 'rbx-19mode' to 'rbx' in .travis.yml and add required Rubinius gems.
