### PR TITLE
Let RestClient use MIME::Types properly

### DIFF
--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -54,7 +54,7 @@ module Coveralls
 
 		def self.hash_to_file(hash)
 			file = nil
-			Tempfile.open(['coveralls-upload', 'json']) do |f|
+			Tempfile.open(['coveralls-upload', '.json']) do |f|
 				f.write(MultiJson.dump hash)
 				file = f
 			end


### PR DESCRIPTION
As I'm working with mime-types 2.x, I'm trying to submit coverage for Ruby 2.x and the code is failing. Part of this is because of a bug with mime-types 2.x (not eliminating `nil` values) and part of this is because the generated tempfile looks like:

`/var/folders/y4/8fxdbz695v52kgdgqdyhxhk80000gq/T/coveralls-upload20140520-38074-1uc3qrtjson`

This change allows it to look like a JSON file based on the extension:

`/var/folders/y4/8fxdbz695v52kgdgqdyhxhk80000gq/T/coveralls-upload20140520-38074-1uc3qrt.json`

This will be compatible for all versions of mime-types.