### PR TITLE
use rest-client which uses a Ruby 1.9.2 compatible version of mime-types

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Coveralls::VERSION
 
-  gem.add_dependency 'rest-client'
+  gem.add_dependency 'rest-client', '1.6.8'
   gem.add_dependency 'term-ansicolor'
   gem.add_dependency 'multi_json', '~> 1.3'
   gem.add_dependency 'thor'


### PR DESCRIPTION
mime-types which rest-client uses is no longer compatible with Ruby 1.9.2

I issued a PR to rest-client, which supports Ruby 1.9.2, to be more restrictive about the version of the mime-types gem used.

https://github.com/rest-client/rest-client/pull/322

In the meantime this PR pins rest-client v1.6.8 which uses mime-types 1.25.1