### PR TITLE
Relaxed dependencies

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Coveralls::VERSION
 
-  gem.add_dependency 'rest-client','1.6.7'
-  gem.add_dependency 'term-ansicolor', '1.2.2'
-  gem.add_dependency 'multi_json', '~> 1.3'
-  gem.add_dependency 'thor', '0.18.1'
+  gem.add_dependency 'rest-client','~> 1'
+  gem.add_dependency 'term-ansicolor', '~> 1'
+  gem.add_dependency 'multi_json', '~> 1'
+  gem.add_dependency 'thor', '~> 0.19.1'
 
   if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("1.9")
     gem.add_dependency 'simplecov', ">= 0.7"
@@ -26,8 +26,8 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('jruby-openssl') if RUBY_PLATFORM == 'java'
 
-  gem.add_development_dependency 'rspec', '2.14.1'
-  gem.add_development_dependency 'rake', '10.0.3'
-  gem.add_development_dependency 'webmock', '1.7'
-  gem.add_development_dependency 'vcr', '1.11.3'
+  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'webmock'
+  gem.add_development_dependency 'vcr'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,9 +27,9 @@ setup_formatter
 
 require 'coveralls'
 
-VCR.config do |c|
+VCR.configure do |c|
   c.cassette_library_dir = 'fixtures/vcr_cassettes'
-  c.stub_with :webmock
+  c.hook_into :webmock
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Hi,

This PR relax dependencies, hoping that other gems are using semver.

Thor, the only gem at version 0, is locked at `~> 0.19.1`, hoping that patch level is enough to keep compatibility

I completely removed versions for development gems 

Updated VCR configuration
Fixes #60
