### PR TITLE
Strengthened dependencies

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -15,19 +15,19 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Coveralls::VERSION
 
-  gem.add_dependency 'rest-client','~> 1'
-  gem.add_dependency 'term-ansicolor', '~> 1'
-  gem.add_dependency 'multi_json', '~> 1'
+  gem.add_dependency 'rest-client','~> 1.7'
+  gem.add_dependency 'term-ansicolor', '~> 1.3'
+  gem.add_dependency 'multi_json', '~> 1.10'
   gem.add_dependency 'thor', '~> 0.19.1'
 
   if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("1.9")
-    gem.add_dependency 'simplecov', ">= 0.7"
+    gem.add_dependency 'simplecov', '~> 0.9.1'
   end
 
-  gem.add_runtime_dependency('jruby-openssl') if RUBY_PLATFORM == 'java'
+  gem.add_dependency('jruby-openssl', '~> 0.9.5') if RUBY_PLATFORM == 'java'
 
-  gem.add_development_dependency 'rspec'
-  gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'webmock'
-  gem.add_development_dependency 'vcr'
+  gem.add_development_dependency 'rspec', '~> 3.1'
+  gem.add_development_dependency 'rake', '~> 10.4'
+  gem.add_development_dependency 'webmock', '~> 1.20'
+  gem.add_development_dependency 'vcr', '~> 2.9'
 end


### PR DESCRIPTION
- Strengthened dependencies, as per http://bundler.io/rationale.html
- Removed `add_runtime_dependency` alias in favour of `add_dependency` in gemspec to keep uniformity
