### PR TITLE
Added license to gemspec

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = "A Ruby implementation of the Coveralls API."
   gem.summary       = "A Ruby implementation of the Coveralls API."
   gem.homepage      = "https://coveralls.io"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Some companies [will only use gems with a certain license](https://github.com/rubygems/rubygems.org/issues/363#issuecomment-5079786).
The canonical and easy way to check is [via the gemspec](http://docs.rubygems.org/read/chapter/20#license)
via e.g. 

    spec.license = 'MIT'
    # or
    spec.licenses = ['MIT', 'GPL-2']

