### PR TITLE
Remove explicit reference to Travis

### DIFF
--- a/lib/coveralls.rb
+++ b/lib/coveralls.rb
@@ -79,7 +79,7 @@ module Coveralls
   def should_run?
     # Fail early if we're not on a CI
     unless will_run?
-      Coveralls::Output.puts("[Coveralls] Outside the Travis environment, not sending data.", :color => "yellow")
+      Coveralls::Output.puts("[Coveralls] Outside the CI environment, not sending data.", :color => "yellow")
       return false
     end
 


### PR DESCRIPTION
Replace the message "Outside the Travis environment" shown when not on a CI with "Outside the CI environment"