### PR TITLE
Fixed repo_token being displayed in clear text

### DIFF
--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -65,7 +65,7 @@ module Coveralls
 			config = Coveralls::Configuration.configuration
 			if ENV['CI'] || ENV['COVERALLS_DEBUG'] || Coveralls.testing
         Coveralls::Output.puts "[Coveralls] Submitting with config:", :color => "yellow"
-        output = MultiJson.dump(config, :pretty => true).gsub(/"repo_token": "(.*?)"/,'"repo_token": "[secure]"')
+        output = MultiJson.dump(config, :pretty => true).gsub(/"repo_token": ?"(.*?)"/,'"repo_token": "[secure]"')
         Coveralls::Output.puts output, :color => "yellow"
 			end
 			hash.merge(config)


### PR DESCRIPTION
Spaces after columns can be missing the JSON output. Because of that, `repo_token` value is not replaced by `[secure]`. See https://travis-ci.org/amercier/oeco/builds/47742447 as an example.