### PR TITLE
add correct sha details for semaphoreapp

### DIFF
--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -182,6 +182,11 @@ module Coveralls
             :branch => ENV['GIT_BRANCH'],
             :commit_sha => ENV['GIT_COMMIT']
           }
+        elsif ENV['SEMAPHORE']
+          {
+            :branch => ENV['BRANCH_NAME'],
+            :commit_sha => ENV['REVISION']
+          }
         else
           {}
         end


### PR DESCRIPTION
I'm using semaphoreapp for CI and some non-insignficant fraction of the time the message I get from slack is for a really old commit and I'm confident that that the test run didn't use this commit.  I'm not sure how coveralls figures out the correct commit but semaphoreapp is supposed to provide it in environment variables and it looks like there is code to use that sort of setup for a number of CI providers.  This pull request just adds the same for semaphoreapp.  