### PR TITLE
Relax rest-client dependency

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--warn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
   - jruby-19mode
+  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.0
   - ruby-head
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,10 @@ platforms :ruby_18 do
   gem 'rest-client', '~> 1.6.0'
 end
 
+platforms :jruby do
+  gem 'jruby-openssl', '~> 0.9.5'
+end
+
 gem 'simplecov', :require => false
 gem 'truthy'
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,11 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in coveralls-ruby.gemspec
 gemspec
 
+platforms :ruby_18 do
+  gem 'mime-types', '~> 1.25'
+  gem 'rest-client', '~> 1.6.0'
+end
+
 gem 'simplecov', :require => false
 gem 'truthy'
 

--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Coveralls::VERSION
 
-  gem.add_dependency 'rest-client','~> 1.7'
+  gem.add_dependency 'rest-client', '>= 1.6.8', '< 2'
   gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'multi_json', '~> 1.10'
   gem.add_dependency 'thor', '~> 0.19.1'

--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -16,16 +16,11 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Coveralls::VERSION
 
-  gem.add_dependency 'rest-client', '>= 1.6.8', '< 2'
-  gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'multi_json', '~> 1.10'
+  gem.add_dependency 'rest-client', '>= 1.6.8', '< 2'
+  gem.add_dependency 'simplecov', '~> 0.9.1'
+  gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'thor', '~> 0.19.1'
-
-  if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("1.9")
-    gem.add_dependency 'simplecov', '~> 0.9.1'
-  end
-
-  gem.add_dependency('jruby-openssl', '~> 0.9.5') if RUBY_PLATFORM == 'java'
 
   gem.add_development_dependency 'rspec', '~> 3.1'
   gem.add_development_dependency 'rake', '~> 10.4'

--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -1,5 +1,6 @@
-# -*- encoding: utf-8 -*-
-require File.expand_path('../lib/coveralls/version', __FILE__)
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'coveralls/version'
 
 Gem::Specification.new do |gem|
   gem.authors       = ["Nick Merwin", "Wil Gieseler"]

--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -143,8 +143,7 @@ module Coveralls
         }
 
         # Branch
-        branch = `git branch`.split("\n").delete_if { |i| i[0] != "*" }
-        hash[:branch] = [branch].flatten.first.gsub("* ","")
+        hash[:branch] = `git rev-parse --abbrev-ref HEAD`
 
         # Remotes
         remotes = nil

--- a/spec/coveralls/configuration_spec.rb
+++ b/spec/coveralls/configuration_spec.rb
@@ -173,9 +173,9 @@ describe Coveralls::Configuration do
 
     it 'should set the service_name to a value if one is passed in' do
       config = {}
-      service_name = SecureRandom.hex(4)
-      Coveralls::Configuration.set_service_params_for_travis(config, service_name)
-      config[:service_name].should eq(service_name)
+      random_name = SecureRandom.hex(4)
+      Coveralls::Configuration.set_service_params_for_travis(config, random_name)
+      config[:service_name].should eq(random_name)
     end
   end
 

--- a/spec/coveralls/coveralls_spec.rb
+++ b/spec/coveralls/coveralls_spec.rb
@@ -82,7 +82,7 @@ describe Coveralls do
   end
 
   describe "#push!" do
-    it "sends existings test results" do
+    it "sends existings test results", :if => RUBY_VERSION >= "1.9" do
       result = false
       silence do
         result = subject.push!

--- a/spec/coveralls/simplecov_spec.rb
+++ b/spec/coveralls/simplecov_spec.rb
@@ -30,7 +30,7 @@ describe Coveralls::SimpleCov::Formatter do
         Coveralls.noisy = false
       end
 
-      it "posts json" do
+      it "posts json", :if => RUBY_VERSION >= "1.9" do
         result.files.should_not be_empty
         silence do
           Coveralls::SimpleCov::Formatter.new.format(result).should be_truthy


### PR DESCRIPTION
This gem does not specify an explicit minimum Ruby version but there is an implicit minimum Ruby version of 1.9.2, since it depends on `rest-client` 1.7 or greater. I’ve very slightly relaxed this dependency to allow `rest-client` version 1.6.8, which works on Ruby 1.8.7. This will allow the latest version of this library to be installed on Ruby 1.8.7, which is convenient for projects that still run tests against this version of Ruby (even though code coverage will not work). I’ve resorted to [locking to `rest-client` 1.6.8](https://github.com/sferik/twitter/commit/aa6a81d015057196247f681d32e11f962ad71aab) on gems that are still tested against Ruby 1.8.7, which has the effect of installing `coveralls` 0.7.1 (the last version to allow this version of `rest-client`). I have also added Ruby 1.8.7 to the test matrix to ensure this doesn’t break in the future and cleaned up a few other Ruby warnings and whatnot. Everything is in separate commits, so you can `get cherry-pick` just the changes you like.