### PR TITLE
allow git configuration through ENV

### DIFF
--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -134,16 +134,16 @@ module Coveralls
       Dir.chdir(root) do
 
         hash[:head] = {
-          :id => `git log -1 --pretty=format:'%H'`,
-          :author_name => `git log -1 --pretty=format:'%aN'`,
-          :author_email => `git log -1 --pretty=format:'%ae'`,
-          :committer_name => `git log -1 --pretty=format:'%cN'`,
-          :committer_email => `git log -1 --pretty=format:'%ce'`,
-          :message => `git log -1 --pretty=format:'%s'`
+          :id => ENV.fetch("GIT_ID", `git log -1 --pretty=format:'%H'`),
+          :author_name => ENV.fetch("GIT_AUTHOR_NAME", `git log -1 --pretty=format:'%aN'`),
+          :author_email => ENV.fetch("GIT_AUTHOR_EMAIL", `git log -1 --pretty=format:'%ae'`),
+          :committer_name => ENV.fetch("GIT_COMMITTER_NAME", `git log -1 --pretty=format:'%cN'`),
+          :committer_email => ENV.fetch("GIT_COMMITTER_EMAIL", `git log -1 --pretty=format:'%ce'`),
+          :message => ENV.fetch("GIT_MESSAGE", `git log -1 --pretty=format:'%s'`)
         }
 
         # Branch
-        hash[:branch] = `git rev-parse --abbrev-ref HEAD`
+        hash[:branch] = ENV.fetch("GIT_BRANCH", `git rev-parse --abbrev-ref HEAD`)
 
         # Remotes
         remotes = nil

--- a/spec/coveralls/configuration_spec.rb
+++ b/spec/coveralls/configuration_spec.rb
@@ -281,5 +281,34 @@ describe Coveralls::Configuration do
     end
   end
 
+  describe '.git' do
+    let(:git_id) { SecureRandom.hex(2) }
+    let(:author_name) { SecureRandom.hex(4) }
+    let(:author_email) { SecureRandom.hex(4) }
+    let(:committer_name) { SecureRandom.hex(4) }
+    let(:committer_email) { SecureRandom.hex(4) }
+    let(:message) { SecureRandom.hex(4) }
+    let(:branch) { SecureRandom.hex(4) }
 
+    before do
+      allow(ENV).to receive(:fetch).with('GIT_ID', anything).and_return(git_id)
+      allow(ENV).to receive(:fetch).with('GIT_AUTHOR_NAME', anything).and_return(author_name)
+      allow(ENV).to receive(:fetch).with('GIT_AUTHOR_EMAIL', anything).and_return(author_email)
+      allow(ENV).to receive(:fetch).with('GIT_COMMITTER_NAME', anything).and_return(committer_name)
+      allow(ENV).to receive(:fetch).with('GIT_COMMITTER_EMAIL', anything).and_return(committer_email)
+      allow(ENV).to receive(:fetch).with('GIT_MESSAGE', anything).and_return(message)
+      allow(ENV).to receive(:fetch).with('GIT_BRANCH', anything).and_return(branch)
+    end
+
+    it 'uses ENV vars' do
+      config = Coveralls::Configuration.git
+      config[:head][:id].should eq(git_id)
+      config[:head][:author_name].should eq(author_name)
+      config[:head][:author_email].should eq(author_email)
+      config[:head][:committer_name].should eq(committer_name)
+      config[:head][:committer_email].should eq(committer_email)
+      config[:head][:message].should eq(message)
+      config[:branch].should eq(branch)
+    end
+  end
 end


### PR DESCRIPTION
In the case where the entire code base is put through some build process for a PR, `HEAD` of the working tree may not be correct, or it may not even exist.
This allows users to inject PR data into the job _after_ changes are made to the working tree.