### PR TITLE
Don't relax rest-client dependency

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.version       = Coveralls::VERSION
 
   gem.add_dependency 'multi_json', '~> 1.10'
-  gem.add_dependency 'rest-client', '~> 1.7.0'
+  gem.add_dependency 'rest-client', '>= 1.6.8', '< 1.8'
   gem.add_dependency 'simplecov', '~> 0.9.1'
   gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'thor', '~> 0.19.1'

--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.version       = Coveralls::VERSION
 
   gem.add_dependency 'multi_json', '~> 1.10'
-  gem.add_dependency 'rest-client', '>= 1.6.8', '< 1.8'
+  gem.add_dependency 'rest-client', '~> 1.7.0'
   gem.add_dependency 'simplecov', '~> 0.9.1'
   gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'thor', '~> 0.19.1'

--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.version       = Coveralls::VERSION
 
   gem.add_dependency 'multi_json', '~> 1.10'
-  gem.add_dependency 'rest-client', '>= 1.6.8', '< 2'
+  gem.add_dependency 'rest-client', '>= 1.6.8', '< 1.8'
   gem.add_dependency 'simplecov', '~> 0.9.1'
   gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'thor', '~> 0.19.1'


### PR DESCRIPTION
Hi,

It appears the change here 3e0cf7695 breaks on JRuby.

The reason I believe is caused by `rest-client v1.8+` which adds a new dependency: `http-cookie` which requires `domain_name` which requires `unf` which requires `unf_ext` which is a **native C gem**. :rage1: 