### PR TITLE
Use ~> to allow tins security patches while remaining compatible with older Ruby versions

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rest-client', '>= 1.6.8', '< 2'
   gem.add_dependency 'simplecov', '~> 0.10.0'
   gem.add_dependency 'tins', '1.6.0'
-  gem.add_dependency 'term-ansicolor', '1.3'
+  gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'thor', '~> 0.19.1'
 
   gem.add_development_dependency 'bundler', '~> 1.7'

--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'json', '~> 1.8'
   gem.add_dependency 'rest-client', '>= 1.6.8', '< 2'
   gem.add_dependency 'simplecov', '~> 0.10.0'
-  gem.add_dependency 'tins', '1.6.0'
+  gem.add_dependency 'tins', '~> 1.6.0'
   gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'thor', '~> 0.19.1'
 


### PR DESCRIPTION
The pessimistic version constraint will allow patch updates to `tins`, e.g., if 1.6.1 is released, without installing `tins` >= 1.7.0, thus maintaining compatibility with Ruby 1.8.7 and Ruby 1.9. I also reverted fa369825e980663220d99726783ba37044f1a3b8, which was not necessary, since there is no required Ruby version specified for `term-ansicolor` itself, so there’s no reason why `term-ansicolor` should be locked to this specific version.