### PR TITLE
display api debug only when debug enabled

### DIFF
--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -62,7 +62,7 @@ module Coveralls
 
     def self.apified_hash hash
       config = Coveralls::Configuration.configuration
-      if ENV['CI'] || ENV['COVERALLS_DEBUG'] || Coveralls.testing
+      if ENV['COVERALLS_DEBUG'] || Coveralls.testing
         Coveralls::Output.puts "[Coveralls] Submitting with config:", :color => "yellow"
         output = JSON.pretty_generate(config).gsub(/"repo_token": ?"(.*?)"/,'"repo_token": "[secure]"')
         Coveralls::Output.puts output, :color => "yellow"


### PR DESCRIPTION
Hello,

The api debug information always displays. because `ENV['CI']` is always set.
We do not look at these messages.

The main issue is that this debug text moves our build failures further away from the bottom of our Travis logs. So it gets in the way.

This still shows the api debug information, but just when it is enabled via `ENV['COVERALLS_DEBUG']` or `Coveralls.testing`.

Thanks

---
**before:** (even though debug is turned off)

```
Failed examples:
rspec ./spec/models/metric/capture_spec.rb:76 # Metric::Capture.perf_capture_health_check should queue up realtime capture for vm
Randomized with seed 46205
[Coveralls] Submitting with config:
{
  "environment": {
    "pwd": "/home/travis/build/ManageIQ/manageiq",
    "rails_root": "/home/travis/build/ManageIQ/manageiq",
    "simplecov_root": "/home/travis/build/ManageIQ/manageiq",
    "gem_version": "0.8.10",
    "travis_job_id": "108542883",
    "travis_pull_request": "5941"
  },
  "git": {
    "head": {
      "id": "5960b6780ce3d2b35b3a66ae6c7c7b512dcfaa4b",
      "author_name": "Keenan Brock",
      "author_email": "keenan@thebrocks.net",
      "committer_name": "Keenan Brock",
      "committer_email": "keenan@thebrocks.net",
      "message": "Merge 91655aae0d374daed8b2dbfe28d582705a7f9700 into 5d4cf1d45c475b559e432ac55686555f0d5ee9ac"
    },
    "branch": "HEAD\n",
    "remotes": [
      {
        "name": "origin",
        "url": "https://github.com/ManageIQ/manageiq.git"
      }
    ]
  },
  "service_job_id": "108542883",
  "service_pull_request": "5941",
  "service_name": "travis-ci",
  "service_number": null,
  "service_build_url": null,
  "service_branch": null
}
[Coveralls] Submitting to https://coveralls.io/api/v1
[Coveralls] Job #22254.1
[Coveralls] https://coveralls.io/jobs/11949279
Coverage is at 54.0%.
Coverage report sent to Coveralls.
The command "bundle exec rake ${TEST_SUITE+test:$TEST_SUITE}" exited with 1.
```

**after:** (estimated - we currently use standard gem for build)

```
Failed examples:
rspec ./spec/models/metric/capture_spec.rb:76 # Metric::Capture.perf_capture_health_check should queue up realtime capture for vm
Randomized with seed 46205
[Coveralls] Submitting to https://coveralls.io/api/v1
[Coveralls] Job #22254.1
[Coveralls] https://coveralls.io/jobs/11949279
Coverage is at 54.0%.
Coverage report sent to Coveralls.
The command "bundle exec rake ${TEST_SUITE+test:$TEST_SUITE}" exited with 1.
```