### PR TITLE
Remove RestClient dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'webmock', '>= 1.20'
 
 platforms :ruby_18 do
   gem 'mime-types', '~> 1.25'
-  gem 'rest-client', '~> 1.6.0'
+  gem 'addressable', '~> 2.3.8', :group => :test
 end
 
 platforms :jruby do

--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.8.7'
 
   gem.add_dependency 'json', '~> 1.8'
-  gem.add_dependency 'rest-client', '>= 1.6.8', '< 2'
   gem.add_dependency 'simplecov', '~> 0.11.0'
   gem.add_dependency 'tins', '~> 1.6.0'
   gem.add_dependency 'term-ansicolor', '~> 1.3'

--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'rest_client'
+require 'net/http'
 
 module Coveralls
   class API
@@ -16,20 +16,30 @@ module Coveralls
 
     def self.post_json(endpoint, hash)
       disable_net_blockers!
-      url = endpoint_to_url(endpoint)
+
+      uri = endpoint_to_uri(endpoint)
+
       Coveralls::Output.puts("#{ JSON.pretty_generate(hash) }", :color => "green") if ENV['COVERALLS_DEBUG']
-      hash = apified_hash hash
       Coveralls::Output.puts("[Coveralls] Submitting to #{API_BASE}", :color => "cyan")
-      response = RestClient::Request.execute(:method => :post, :url => url, :payload => { :json_file => hash_to_file(hash) }, :ssl_version => 'TLSv1', :verify_ssl => false)
-      response_hash = JSON.load(response.to_str)
+
+      client  = build_client(uri)
+      request = build_request(uri.path, hash)
+
+      response = client.request(request)
+
+      response_hash = JSON.load(response.body.to_str)
       Coveralls::Output.puts("[Coveralls] #{ response_hash['message'] }", :color => "cyan")
-      if response_hash['message']
+
+      if response_hash['url']
         Coveralls::Output.puts("[Coveralls] #{ Coveralls::Output.format(response_hash['url'], :color => "underline") }", :color => "cyan")
       end
-    rescue RestClient::ServiceUnavailable
-      Coveralls::Output.puts("[Coveralls] API timeout occured, but data should still be processed", :color => "red")
-    rescue RestClient::InternalServerError
-      Coveralls::Output.puts("[Coveralls] API internal error occured, we're on it!", :color => "red")
+
+      case response
+      when Net::HTTPServiceUnavailable
+        Coveralls::Output.puts("[Coveralls] API timeout occured, but data should still be processed", :color => "red")
+      when Net::HTTPInternalServerError
+        Coveralls::Output.puts("[Coveralls] API internal error occured, we're on it!", :color => "red")
+      end
     end
 
     private
@@ -47,8 +57,38 @@ module Coveralls
       end
     end
 
-    def self.endpoint_to_url(endpoint)
-      "#{API_BASE}/#{endpoint}"
+    def self.endpoint_to_uri(endpoint)
+      URI.parse("#{API_BASE}/#{endpoint}")
+    end
+
+    def self.build_client(uri)
+      client = Net::HTTP.new(uri.host, uri.port)
+      client.use_ssl = true if uri.port == 443
+      client.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      client.ssl_version = 'TLSv1'
+
+      client
+    end
+
+    def self.build_request(path, hash)
+      request  = Net::HTTP::Post.new(path)
+      boundary = rand(1_000_000).to_s
+
+      request.body         = build_request_body(hash, boundary)
+      request.content_type = "multipart/form-data, boundary=#{boundary}"
+
+      request
+    end
+
+    def self.build_request_body(hash, boundary)
+      hash = apified_hash(hash)
+      file = hash_to_file(hash)
+
+      "--#{boundary}\r\n" \
+      "Content-Disposition: form-data; name=\"json_file\"; filename=\"#{File.basename(file)}\"\r\n" \
+      "Content-Type: text/plain\r\n\r\n" +
+      File.read(file) +
+      "\r\n--#{boundary}--\r\n"
     end
 
     def self.hash_to_file(hash)

--- a/spec/coveralls/simplecov_spec.rb
+++ b/spec/coveralls/simplecov_spec.rb
@@ -62,7 +62,8 @@ describe Coveralls::SimpleCov::Formatter do
 
     context "with api error" do
       it "rescues" do
-        e = RestClient::ResourceNotFound.new double('HTTP Response', :code => '502')
+        e = SocketError.new
+
         silence do
           Coveralls::SimpleCov::Formatter.new.display_error(e).should be_falsy
         end


### PR DESCRIPTION
I'd like to whittle down the list of this gem's dependencies to make it easier to use anywhere.

This change, in particular, will help with some specific apps that are stuck on older versions of rest-client.