### PR TITLE
require 'tempfile'

### DIFF
--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'net/https'
+require 'tempfile'
 
 module Coveralls
   class API


### PR DESCRIPTION
On line 104, the `Tempfile` class was used but the required file was not required.