### PR TITLE
Update tins dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ end
 
 platforms :ruby_18, :ruby_19 do
   gem 'json', '~> 1.8'
+  gem 'tins', '~> 1.6.0'
 end
 
 platforms :jruby do

--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'json', '>= 1.8', '< 3'
   gem.add_dependency 'simplecov', '~> 0.12.0'
-  gem.add_dependency 'tins', '~> 1.6.0'
+  gem.add_dependency 'tins', '>= 1.6.0', '< 2'
   gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'thor', '~> 0.19.1'
 


### PR DESCRIPTION
Should avoid a warning when running `bundle outdated` on a gem which depends on coveralls

```
$ bundle outdated
Fetching gem metadata from https://rubygems.org/
Fetching version metadata from https://rubygems.org/
Fetching dependency metadata from https://rubygems.org/
Resolving dependencies....

Outdated gems included in the bundle:
  * tins (newest 1.11.0, installed 1.6.0)
```