### PR TITLE
Explicitly try to require webmock and vcr

### DIFF
--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -49,15 +49,21 @@ module Coveralls
     private
 
     def self.disable_net_blockers!
-      if defined?(WebMock) &&
+      begin
+        require 'webmock'
+
         allow = WebMock::Config.instance.allow || []
         WebMock::Config.instance.allow = [*allow].push API_HOST
+      rescue LoadError
       end
 
-      if defined?(VCR)
+      begin
+        require 'vcr'
+
         VCR.send(VCR.version.major < 2 ? :config : :configure) do |c|
           c.ignore_hosts API_HOST
         end
+      rescue LoadError
       end
     end
 


### PR DESCRIPTION
The old code would only work if these gems had already been required, but since you should require this gem before everything else, it doesn't work for a lot of people.

This way guarantees the blocks will be added if the gems are available.