### PR TITLE
Fix broken support for rubies < 2.0

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'json', '>= 1.8', '< 3'
   gem.add_dependency 'simplecov', '~> 0.12.0'
   gem.add_dependency 'tins', '>= 1.6.0', '< 2'
-  gem.add_dependency 'term-ansicolor', '~> 1.3'
+  gem.add_dependency 'term-ansicolor', '~> 1.3.0'
   gem.add_dependency 'thor', '~> 0.19.1'
 
   gem.add_development_dependency 'bundler', '~> 1.7'


### PR DESCRIPTION
Currently coveralls-ruby fails to install on Ruby < 2.0 due to
term-ansicolor 1.4.0 only supporting Ruby >= 2.0. Changing coveralls-ruby
requirement on term-ansicolor to ~> 1.3.0 will ensure compatiblity.
This patch attempts fixes the problem and brings coveralls in line
with required ruby version >= 1.8.7.