### PR TITLE
Ignore failures on ruby 1.9 since WebMock stopped supporting the version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.10

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,6 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby
+    # NOTE: The tests never pass with 1.9.3 since WebMock stopped supporting 1.9.
+    - rvm: 1.9.3
   fast_finish: true


### PR DESCRIPTION
Now all the tests on ruby 1.9 has failed since `webmock` on which `coverall-ruby` depend stopped supporting ruby 1.9. 

To resolve this situation, this PR updates on `.travis.yml` to ignore the tests on ruby 1.9. 

It should be reconsidered that which ruby versions should be supported by coverall, I think. 