### PR TITLE
Update simplecov version to 0.14.1

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.8.7'
 
   gem.add_dependency 'json', '>= 1.8', '< 3'
-  gem.add_dependency 'simplecov', '~> 0.12.0'
+  gem.add_dependency 'simplecov', '~> 0.14.1'
   gem.add_dependency 'tins', '~> 1.6'
   gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'thor', '~> 0.19.1'

--- a/spec/coveralls/simplecov_spec.rb
+++ b/spec/coveralls/simplecov_spec.rb
@@ -75,7 +75,7 @@ describe Coveralls::SimpleCov::Formatter do
       it "nils the skipped lines" do
         source_file = source_files.first
         source_file[:coverage].should_not eq result.files.first.coverage
-        source_file[:coverage].should eq [nil, 1, 1, 1, nil, 0, 1, nil, nil, nil]
+        source_file[:coverage].should eq [nil, 1, 1, 1, nil, 0, nil, nil, nil, nil, nil]
       end
     end
   end


### PR DESCRIPTION
Note: simplecov 0.14.0 fixed an issue that was breaking the example at
`spec/coveralls/simplecov_spec.rb:75`.

Before the result of `#get_source_files` for `fixtures/sample.rb` was:

```
00 COUNTED - # Foo class
01 COUNTED - class Foo
02 COUNTED -   def initialize
03 COUNTED -     @foo = 'baz'
04 COUNTED -   end
05 COUNTED -
06 COUNTED -   # :nocov:
07 SKIPPED -   def bar
08 SKIPPED -     @foo
09 SKIPPED -   end
10 COUNTED -   # :nocov:
11 COUNTED - end
```

Using simplecov 0.14.1, that includes
https://github.com/colszowka/simplecov/pull/551, the result is:

```
00 COUNTED - # Foo class
01 COUNTED - class Foo
02 COUNTED -   def initialize
03 COUNTED -     @foo = 'baz'
04 COUNTED -   end
05 COUNTED -
06 SKIPPED -   # :nocov:
07 SKIPPED -   def bar
08 SKIPPED -     @foo
09 SKIPPED -   end
10 SKIPPED -   # :nocov:
11 COUNTED - end
```