### PR TITLE
fix error in `bundle exec coveralls push`

### DIFF
--- a/lib/coveralls/command.rb
+++ b/lib/coveralls/command.rb
@@ -7,7 +7,7 @@ module Coveralls
     def push
       return unless ensure_can_run_locally!
       ENV["COVERALLS_RUN_LOCALLY"] = "true"
-      cmds = "bundle exec rake"
+      cmds = ["bundle exec rake"]
       if File.exist?('.travis.yml')
         cmds = YAML.load_file('.travis.yml')["script"] || cmds rescue cmds
       end


### PR DESCRIPTION
When running this command with a `default: :spec` Rake task and without a `.travis.yml` file, I was getting a NoMethodError:
```
NoMethodError: undefined method `each' for "bundle exec rake":String
```
I resolved this error and pushed successfully by wrapping the command in an array.