### PR TITLE
Fix relative path of filenames when root path has multiple matches.

### DIFF
--- a/lib/coveralls/simplecov.rb
+++ b/lib/coveralls/simplecov.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module Coveralls
   module SimpleCov
     class Formatter
@@ -61,7 +63,7 @@ module Coveralls
         end
 
         # Post to Coveralls.
-        API.post_json "jobs", 
+        API.post_json "jobs",
           :source_files => get_source_files(result),
           :test_framework => result.command_name.downcase,
           :run_at => result.created_at
@@ -92,8 +94,11 @@ module Coveralls
       end
 
       def short_filename(filename)
-        filename = filename.gsub(::SimpleCov.root, '.').gsub(/^\.\//, '') if ::SimpleCov.root
-        filename
+        return filename unless ::SimpleCov.root
+
+        filename = Pathname.new(filename)
+        root = Pathname.new(::SimpleCov.root)
+        filename.relative_path_from(root).to_s
       end
 
     end

--- a/spec/coveralls/simplecov_spec.rb
+++ b/spec/coveralls/simplecov_spec.rb
@@ -79,4 +79,26 @@ describe Coveralls::SimpleCov::Formatter do
       end
     end
   end
+
+  describe "#short_filename" do
+    subject {  formatter.short_filename(filename) }
+    let(:formatter) { Coveralls::SimpleCov::Formatter.new }
+    let(:filename) { '/app/app/controllers/application_controller.rb' }
+
+    before do
+      allow(SimpleCov).to receive(:root).and_return(root_path)
+    end
+
+    context "with no root path" do
+      let(:root_path) { nil }
+
+      it { is_expected.to eql filename }
+    end
+
+    context "with multiple matches of root path" do
+      let(:root_path) { '/app' }
+
+      it { is_expected.to eql 'app/controllers/application_controller.rb' }
+    end
+  end
 end


### PR DESCRIPTION
Use ruby's standard library to resolve relative path. This fixes an issue where
`Coverall.root` matches multiple parts of the `filename` string, and replacing them
with `.`. One example is `/app/app/controllers/applications_controller` would be converted to
`../controller/.lications_controller`.