### PR TITLE
Add source code link to gemspec

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -17,6 +17,10 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Coveralls::VERSION
 
+  gem.metadata = {
+    "source_code_uri" => "https://github.com/lemurheavy/coveralls-ruby",
+  }
+
   gem.required_ruby_version = '>= 1.8.7'
 
   gem.add_dependency 'json', '>= 1.8', '< 3'


### PR DESCRIPTION
This will add a link from the rubygems listing to this repo, and allow tools like Dependabot to find the repo easily when creating update PRs.