### PR TITLE
More lenient thor versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ rvm:
   - ruby-head
   - jruby
 
+before_install:
+  - gem install bundler || gem install bundler --version '< 2'
+
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'simplecov', '~> 0.16.1'
   gem.add_dependency 'tins', '~> 1.6'
   gem.add_dependency 'term-ansicolor', '~> 1.3'
-  gem.add_dependency 'thor', '~> 0.19.4'
+  gem.add_dependency 'thor', '~> 0.19'
 
   gem.add_development_dependency 'bundler', '~> 1.7'
 end


### PR DESCRIPTION
While adding `coveralls` gem to my project, I encountered issues with the `thor` dependency versioning. I have a few gems that need `thor` >= 0.20, but `coveralls` is locked to `< 0.20`.

There are no breaking changes in `thor` version `0.20`: https://github.com/erikhuda/thor/blob/master/CHANGELOG.md#0200

This PR "unlocks" coverall version of `thor`.

One side effect is that this allows version `0.19.0` to be installed, but it doesn't seem like `coveralls` has a strict requirement on `0.19.4`, as the PR that bumped it to `0.19.4` doesn't seem to have any functionality impact: https://github.com/lemurheavy/coveralls-ruby/commit/bcf1f6fa2fc8301d51e71bf9dd858c6a65932353