### PR TITLE
allow to use simplecov over v0.17.0

### DIFF
--- a/coveralls-ruby.gemspec
+++ b/coveralls-ruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.8.7'
 
   gem.add_dependency 'json', '>= 1.8', '< 3'
-  gem.add_dependency 'simplecov', '~> 0.16.1'
+  gem.add_dependency 'simplecov', '>= 0.16.1'
   gem.add_dependency 'tins', '~> 1.6'
   gem.add_dependency 'term-ansicolor', '~> 1.3'
   gem.add_dependency 'thor', '>= 0.19.4', '< 2.0'


### PR DESCRIPTION
Simplecov v0.17.0 was released.
I'd liked to use simplecov v0.17.

https://github.com/colszowka/simplecov/releases/tag/v0.17.0

