### PR TITLE
Change multipart content type delimiter

### DIFF
--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -90,7 +90,7 @@ module Coveralls
       boundary = rand(1_000_000).to_s
 
       request.body         = build_request_body(hash, boundary)
-      request.content_type = "multipart/form-data, boundary=#{boundary}"
+      request.content_type = "multipart/form-data; boundary=#{boundary}"
 
       request
     end


### PR DESCRIPTION
Delimiter for content-type multipart/form-data should use `;` instead of `,`

reference:
- https://stackoverflow.com/questions/35761248/which-separator-should-be-used-in-the-content-type-header-for-a-multipart-data-r
- https://www.rfc-editor.org/errata_search.php?rfc=1867