### PR TITLE
Travis: Drop unused sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 
 cache: bundler
 
-sudo: false
-
 before_install:
   - gem update --system
   - gem install bundler


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).