### PR TITLE
Put cmds in an array

### DIFF
--- a/lib/coveralls/command.rb
+++ b/lib/coveralls/command.rb
@@ -7,7 +7,7 @@ module Coveralls
     def push
       return unless ensure_can_run_locally!
       ENV["COVERALLS_RUN_LOCALLY"] = "true"
-      cmds = "bundle exec rake"
+      cmds = ["bundle exec rake"]
       if File.exist?('.travis.yml')
         cmds = YAML.load_file('.travis.yml')["script"] || cmds rescue cmds
       end


### PR DESCRIPTION
This address issue reported in #105.

`cmds` defaults to a string, which causes the `cmds.each` command to
fail. The only way to manually push is to create a .travis.yml file. To
fix this, wrap the default `cmds` variable in an array, which allows the
`cmds.each` call to successfully call `bundle exec rake` in the case
where a .travis.yml does not exist.