### PR TITLE
Add service_number to gitlab config defaults

### DIFF
--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -99,6 +99,7 @@ module Coveralls
 
     def self.set_service_params_for_gitlab(config)
       config[:service_name]         = 'gitlab-ci'
+      config[:service_number]       = ENV['CI_PIPELINE_ID']
       config[:service_job_number]   = ENV['CI_BUILD_NAME']
       config[:service_job_id]       = ENV['CI_BUILD_ID']
       config[:service_branch]       = ENV['CI_BUILD_REF_NAME']

--- a/spec/coveralls/configuration_spec.rb
+++ b/spec/coveralls/configuration_spec.rb
@@ -224,9 +224,11 @@ describe Coveralls::Configuration do
     let(:service_job_number) { "spec:one" }
     let(:service_job_id) { 1234 }
     let(:service_branch) { "feature" }
+    let(:service_number) { 5678 }
 
     before do
       ENV.stub(:[]).with('CI_BUILD_NAME').and_return(service_job_number)
+      ENV.stub(:[]).with('CI_PIPELINE_ID').and_return(service_number)
       ENV.stub(:[]).with('CI_BUILD_ID').and_return(service_job_id)
       ENV.stub(:[]).with('CI_BUILD_REF_NAME').and_return(service_branch)
       ENV.stub(:[]).with('CI_BUILD_REF').and_return(commit_sha)
@@ -236,6 +238,7 @@ describe Coveralls::Configuration do
       config = {}
       Coveralls::Configuration.set_service_params_for_gitlab(config)
       config[:service_name].should eq('gitlab-ci')
+      config[:service_number].should eq(service_number)
       config[:service_job_number].should eq(service_job_number)
       config[:service_job_id].should eq(service_job_id)
       config[:service_branch].should eq(service_branch)


### PR DESCRIPTION
This PR adds `service_number` to Gitlab's default config, reads [CI_PIPELINE_ID](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html).
This allows to run [parallel builds](https://docs.coveralls.io/parallel-build-webhook) with Gitlab, current code only sets job ID, so no way to post a pipeline ID on the webhook as you get `{"error":"No build matching CI build number <JOB_ID> found"}` as [this build](https://gitlab.com/graphql-devise/graphql_devise/-/jobs/1097196689) shows.

https://github.com/graphql-devise/graphql_devise/pull/160 uses this fork and branch to run a parallel build successfully.

[here](https://gitlab.com/graphql-devise/graphql_devise/-/pipelines/270319900) is the build that works, and here is the [coveralls build](https://coveralls.io/builds/37920579).