### PR TITLE
Fix parallel builds for Gitlab CI and CircleCI

### DIFF
--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -98,11 +98,12 @@ module Coveralls
     end
 
     def self.set_service_params_for_gitlab(config)
-      config[:service_name]         = 'gitlab-ci'
-      config[:service_job_number]   = ENV['CI_BUILD_NAME']
-      config[:service_job_id]       = ENV['CI_BUILD_ID']
-      config[:service_branch]       = ENV['CI_BUILD_REF_NAME']
-      config[:commit_sha]           = ENV['CI_BUILD_REF']
+      config[:service_name]       = 'gitlab-ci'
+      config[:service_number]     = ENV['CI_PIPELINE_ID']
+      config[:service_job_number] = ENV['CI_BUILD_NAME']
+      config[:service_job_id]     = ENV['CI_BUILD_ID']
+      config[:service_branch]     = ENV['CI_BUILD_REF_NAME']
+      config[:commit_sha]         = ENV['CI_BUILD_REF']
     end
 
     def self.set_service_params_for_coveralls_local(config)

--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -60,7 +60,7 @@ module Coveralls
 
     def self.set_service_params_for_circleci(config)
       config[:service_name]         = 'circleci'
-      config[:service_number]       = ENV['CIRCLE_BUILD_NUM']
+      config[:service_number]       = ENV['CIRCLE_WORKFLOW_ID'] || ENV['CIRCLE_BUILD_NUM']
       config[:service_pull_request] = (ENV['CI_PULL_REQUEST'] || "")[/(\d+)$/,1]
       config[:parallel]             = ENV['CIRCLE_NODE_TOTAL'].to_i > 1
       config[:service_job_number]   = ENV['CIRCLE_NODE_INDEX']

--- a/spec/coveralls/configuration_spec.rb
+++ b/spec/coveralls/configuration_spec.rb
@@ -207,8 +207,11 @@ describe Coveralls::Configuration do
 
   describe '.set_service_params_for_circleci' do
     let(:circle_build_num) { SecureRandom.hex(4) }
+    let(:circle_workflow_id) { nil }
+
     before do
       ENV.stub(:[]).with('CIRCLE_BUILD_NUM').and_return(circle_build_num)
+      ENV.stub(:[]).with('CIRCLE_WORKFLOW_ID').and_return(circle_workflow_id)
     end
 
     it 'should set the expected parameters' do
@@ -216,6 +219,17 @@ describe Coveralls::Configuration do
       Coveralls::Configuration.set_service_params_for_circleci(config)
       config[:service_name].should eq('circleci')
       config[:service_number].should eq(circle_build_num)
+    end
+
+    context 'when workflow_id is available' do
+      let(:circle_workflow_id) { SecureRandom.hex(4) }
+
+      it 'should use workflow ID' do
+        config = {}
+        Coveralls::Configuration.set_service_params_for_circleci(config)
+        config[:service_name].should eq('circleci')
+        config[:service_number].should eq(circle_workflow_id)
+      end
     end
   end
 

--- a/spec/coveralls/configuration_spec.rb
+++ b/spec/coveralls/configuration_spec.rb
@@ -224,9 +224,11 @@ describe Coveralls::Configuration do
     let(:service_job_number) { "spec:one" }
     let(:service_job_id) { 1234 }
     let(:service_branch) { "feature" }
+    let(:service_number) { 5678 }
 
     before do
       ENV.stub(:[]).with('CI_BUILD_NAME').and_return(service_job_number)
+      ENV.stub(:[]).with('CI_PIPELINE_ID').and_return(service_number)
       ENV.stub(:[]).with('CI_BUILD_ID').and_return(service_job_id)
       ENV.stub(:[]).with('CI_BUILD_REF_NAME').and_return(service_branch)
       ENV.stub(:[]).with('CI_BUILD_REF').and_return(commit_sha)
@@ -236,6 +238,7 @@ describe Coveralls::Configuration do
       config = {}
       Coveralls::Configuration.set_service_params_for_gitlab(config)
       config[:service_name].should eq('gitlab-ci')
+      config[:service_number].should eq(service_number)
       config[:service_job_number].should eq(service_job_number)
       config[:service_job_id].should eq(service_job_id)
       config[:service_branch].should eq(service_branch)


### PR DESCRIPTION
## Gitlab
- Using `CI_PIPELINE_ID` as `service_number` allows to post results on the same build.
- [Gitlab build using these commits](https://gitlab.com/graphql-devise/graphql_devise/-/pipelines/282455579).
- [coveralls build with multiple jobs for the same build](https://coveralls.io/builds/38305793)
## CircleCI
- `CIRCLE_BUILD_NUM` is different for each job running on a workflow matrix. This might still work for older builds, that's why the same env var is read when not running a workflow.
- [workflow example using these commits](https://app.circleci.com/pipelines/github/graphql-devise/graphql_devise/23/workflows/543c92be-679d-4fcb-8ef1-84bb9cd71204).
- [coveralls build from the workflow above (uses parallel jobs)](https://coveralls.io/builds/38664272).